### PR TITLE
feat: support SCHED_DEADLINE

### DIFF
--- a/ros2_thread_configurator/include/sched_deadline.hpp
+++ b/ros2_thread_configurator/include/sched_deadline.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <linux/sched.h>
 #include <sched.h>
 #include <sys/syscall.h>

--- a/ros2_thread_configurator/include/sched_deadline.hpp
+++ b/ros2_thread_configurator/include/sched_deadline.hpp
@@ -1,0 +1,27 @@
+#include <linux/sched.h>
+#include <sched.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+
+struct sched_attr {
+  uint32_t size;
+
+  uint32_t sched_policy;
+  uint64_t sched_flags;
+
+  /* SCHED_NORMAL, SCHED_BATCH */
+  int32_t sched_nice;
+
+  /* SCHED_FIFO, SCHED_RR */
+  uint32_t sched_priority;
+
+  /* SCHED_DEADLINE (nsec) */
+  uint64_t sched_runtime;
+  uint64_t sched_deadline;
+  uint64_t sched_period;
+};
+
+int sched_setattr(pid_t pid, const struct sched_attr *attr,
+                  unsigned int flags) {
+  return syscall(__NR_sched_setattr, pid, attr, flags);
+}

--- a/ros2_thread_configurator/include/thread_configurator_node.hpp
+++ b/ros2_thread_configurator/include/thread_configurator_node.hpp
@@ -26,11 +26,13 @@ class ThreadConfiguratorNode : public rclcpp::Node {
 
 public:
   ThreadConfiguratorNode(const YAML::Node &yaml);
+  ~ThreadConfiguratorNode();
   bool all_applied();
   void print_all_unapplied();
 
 private:
-  bool issue_syscalls(const CallbackGroupConfig &config) const;
+  bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int>& cpus);
+  bool issue_syscalls(const CallbackGroupConfig &config);
   void topic_callback(const thread_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
 
   rclcpp::Subscription<thread_config_msgs::msg::CallbackGroupInfo>::SharedPtr subscription_;
@@ -38,5 +40,6 @@ private:
   std::vector<CallbackGroupConfig> callback_group_configs_;
   std::unordered_map<std::string, CallbackGroupConfig*> id_to_callback_group_config_;
   int unapplied_num_;
+  int cgroup_num_;
 };
 

--- a/ros2_thread_configurator/include/thread_configurator_node.hpp
+++ b/ros2_thread_configurator/include/thread_configurator_node.hpp
@@ -15,6 +15,12 @@ class ThreadConfiguratorNode : public rclcpp::Node {
     std::vector<int> affinity;
     std::string policy;
     int priority;
+
+    // For SCHED_DEADLINE
+    unsigned int runtime;
+    unsigned int period;
+    unsigned int deadline;
+
     bool applied = false;
   };
 

--- a/ros2_thread_configurator/src/main.cpp
+++ b/ros2_thread_configurator/src/main.cpp
@@ -28,7 +28,10 @@ static void spin_thread_configurator_node(const std::string &config_filename) {
   }
 
   if (node->all_applied()) {
-    RCLCPP_INFO(node->get_logger(), "Success: All of the configurations are applied. shutting down...");
+    RCLCPP_INFO(node->get_logger(),
+                "Success: All of the configurations are applied. "
+                "Press enter to exit and remove cgroups:");
+    std::cin.get();
   } else {
     node->print_all_unapplied();
   }

--- a/ros2_thread_configurator/src/thread_configurator_node.cpp
+++ b/ros2_thread_configurator/src/thread_configurator_node.cpp
@@ -1,5 +1,7 @@
 #include <string>
 #include <unordered_map>
+#include <fstream>
+#include <filesystem>
 
 #include <error.h>
 #include <sys/time.h>
@@ -13,7 +15,7 @@
 #include "thread_configurator_node.hpp"
 #include "sched_deadline.hpp"
 
-ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml) : Node("thread_configurator_node"), unapplied_num_(0) {
+ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml) : Node("thread_configurator_node"), unapplied_num_(0), cgroup_num_(0) {
   {
     YAML::Node callback_groups = yaml["callback_groups"];
     unapplied_num_ = callback_groups.size();
@@ -42,6 +44,14 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml) : Node("t
     "/ros2_thread_configurator/callback_group_info", 0 /* infinite queue size*/, std::bind(&ThreadConfiguratorNode::topic_callback, this, std::placeholders::_1));
 }
 
+ThreadConfiguratorNode::~ThreadConfiguratorNode() {
+  if (cgroup_num_ > 0) {
+    for (int i = 0; i < cgroup_num_; i++) {
+      rmdir(("/sys/fs/cgroup/cpuset/" + std::to_string(i)).c_str());
+    }
+  }
+}
+
 bool ThreadConfiguratorNode::all_applied() {
   return unapplied_num_ == 0;
 }
@@ -56,18 +66,37 @@ void ThreadConfiguratorNode::print_all_unapplied() {
   }
 }
 
-bool ThreadConfiguratorNode::issue_syscalls(const CallbackGroupConfig &config) const {
-  if (config.affinity.size() > 0) {
-    cpu_set_t set;
-    CPU_ZERO(&set);
-    for (int cpu : config.affinity) CPU_SET(cpu, &set);
-    if (sched_setaffinity(config.thread_id, sizeof(set), &set) == -1) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to configure affinity (id=%s, tid=%ld): %s",
-          config.callback_group_id.c_str(), config.thread_id, strerror(errno));
-      return false;
-    }
+bool ThreadConfiguratorNode::set_affinity_by_cgroup(int64_t thread_id, const std::vector<int>& cpus) {
+  std::string cgroup_path = "/sys/fs/cgroup/cpuset/" + std::to_string(cgroup_num_++);
+  if (!std::filesystem::create_directory(cgroup_path)) {
+    return false;
   }
 
+  std::string cpus_path = cgroup_path + "/cpuset.cpus";
+  if (std::ofstream cpus_file{cpus_path}) {
+    for (int cpu : cpus) cpus_file << cpu << ",";
+  } else {
+    return false;
+  }
+
+  std::string mems_path = cgroup_path + "/cpuset.mems";
+  if (std::ofstream mems_file{mems_path}) {
+    mems_file << 0;
+  } else {
+    return false;
+  }
+
+  std::string tasks_path = cgroup_path + "/tasks";
+  if (std::ofstream procs_file{tasks_path}) {
+    procs_file << thread_id;
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+bool ThreadConfiguratorNode::issue_syscalls(const CallbackGroupConfig &config) {
   if (config.policy == "SCHED_OTHER" || config.policy == "SCHED_BATCH" || config.policy == "SCHED_IDLE") {
     struct sched_param param;
     param.sched_priority = 0;
@@ -122,6 +151,26 @@ bool ThreadConfiguratorNode::issue_syscalls(const CallbackGroupConfig &config) c
       RCLCPP_ERROR(this->get_logger(), "Failed to configure policy (id=%s, tid=%ld): %s",
           config.callback_group_id.c_str(), config.thread_id, strerror(errno));
       return false;
+    }
+  }
+
+  if (config.affinity.size() > 0) {
+    if (config.policy == "SCHED_DEADLINE") {
+      if (!set_affinity_by_cgroup(config.thread_id, config.affinity)) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to configure affinity (id=%s, tid=%ld): %s",
+            config.callback_group_id.c_str(), config.thread_id, "Please disable cgroup v2 if used: `systemd.unified_cgroup_hierarchy=0`");
+        return false;
+        }
+
+    } else {
+      cpu_set_t set;
+      CPU_ZERO(&set);
+      for (int cpu : config.affinity) CPU_SET(cpu, &set);
+      if (sched_setaffinity(config.thread_id, sizeof(set), &set) == -1) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to configure affinity (id=%s, tid=%ld): %s",
+            config.callback_group_id.c_str(), config.thread_id, strerror(errno));
+        return false;
+      }
     }
   }
 

--- a/ros2_thread_configurator/src/thread_configurator_node.cpp
+++ b/ros2_thread_configurator/src/thread_configurator_node.cpp
@@ -87,8 +87,8 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(int64_t thread_id, const std
   }
 
   std::string tasks_path = cgroup_path + "/tasks";
-  if (std::ofstream procs_file{tasks_path}) {
-    procs_file << thread_id;
+  if (std::ofstream tasks_file{tasks_path}) {
+    tasks_file << thread_id;
   } else {
     return false;
   }


### PR DESCRIPTION
# NOTE

- Since `sched_setaffinity(2)` cannot be used for the SCHED_DEADLINE task, affinity is set in the cpuset of cgroup v1: https://stackoverflow.com/questions/50165719/sched-setaffinity-for-sched-deadline

- In ubuntu 22.04, `struct sched_attr` and `sched_setattr()` need to be redefined: https://stackoverflow.com/questions/50082317/is-sched-deadline-officially-supported-in-ubuntu-16-04?noredirect=1&lq=1