### PR TITLE
Add missing namespace brace

### DIFF
--- a/component_container_callback_isolated/src/component_container_rt.cpp
+++ b/component_container_callback_isolated/src/component_container_rt.cpp
@@ -43,5 +43,6 @@ int main(int argc, char * argv[])
   auto node = std::make_shared<rclcpp_components::ComponentManagerRt>();
   exec->add_node(node);
   exec->spin();
+  rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
Add missing namespace brace and return statement to make the build process succesful.